### PR TITLE
Update one of the `cputime_start` declarations to `cputime_stop`

### DIFF
--- a/lib/gvl_timing.rb
+++ b/lib/gvl_timing.rb
@@ -31,7 +31,7 @@ module GVLTiming
     [
       :duration, :cpu_duration,
       :monotonic_start, :monotonic_stop,
-      :cputime_start, :cputime_start,
+      :cputime_start, :cputime_stop,
       :running_duration, :stalled_duration, :idle_duration
     ].each do |name|
       class_eval <<~RUBY


### PR DESCRIPTION
I think this might be a typo or from a copy-&-paste. The intended name was probably `cputime_stop`.